### PR TITLE
Async POST + Notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.1'
+def runeLiteVersion = '1.7.2.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -1,4 +1,4 @@
-package com.botdetector;
+package net.runelite.client.plugins.botdetector;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -45,27 +45,21 @@ public class BotDetectorPlugin extends Plugin {
                 .build();
 
         Call call = okclient.newCall(request);
-        call.enqueue(new Callback()
-        {
+        call.enqueue(new Callback() {
             @Override
-            public void onFailure(Call call, IOException e)
-            {
+            public void onFailure(Call call, IOException e) {
                 notifier.notify("Bot Detector: Player Name List Upload Failed.");
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException
-            {
-                if(response.isSuccessful())
-                {
+            public void onResponse(Call call, Response response) throws IOException {
+                if (response.isSuccessful()) {
                     notifier.notify("Bot Detector: " +
                             submissionSet.size() +
                             " Player Names Uploaded Successfully!");
 
                     submissionSet.clear();
-                }
-                else
-                {
+                } else {
                     notifier.notify("Bot Detector: Player Name List Upload Failed.");
                 }
             }
@@ -82,24 +76,15 @@ public class BotDetectorPlugin extends Plugin {
     private BotDetectorConfig config;
 
     @Provides
-    BotDetectorConfig provideConfig(ConfigManager configManager)
-    {
+    BotDetectorConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(BotDetectorConfig.class);
     }
+
     @Subscribe
     public void onPlayerSpawned(PlayerSpawned event) throws IOException {
         Player player = event.getPlayer();
-        String playerName = player.getName();
-
-        if(h.contains(playerName))
-        {
-            assert true;
-        }
-        else
-        {
-            h.add(playerName);
-            System.out.println(player.getName());
-        }
+        h.add(player.getName());
+        System.out.println(player.getName());
     }
 
     @Subscribe

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -45,17 +45,24 @@ public class BotDetectorPlugin extends Plugin {
                 .build();
 
         Call call = okclient.newCall(request);
-        call.enqueue(new Callback() {
+        call.enqueue(new Callback()
+        {
             @Override
-            public void onFailure(Call call, IOException e) {
+            public void onFailure(Call call, IOException e)
+            {
                 notifier.notify("Bot Detector: Player Name List Upload Failed.");
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
-                if(response.isSuccessful()) {
+            public void onResponse(Call call, Response response) throws IOException
+            {
+                if(response.isSuccessful())
+                {
+                    notifier.notify("Bot Detector: " +
+                            submissionSet.size() +
+                            " Player Names Uploaded Successfully!");
+
                     submissionSet.clear();
-                    notifier.notify("Bot Detector: Player Name List Uploaded Successfully!");
                 }
                 else
                 {
@@ -68,7 +75,8 @@ public class BotDetectorPlugin extends Plugin {
     @Inject
     private Client client;
 
-    @Inject Notifier notifier;
+    @Inject
+    private Notifier notifier;
 
     @Inject
     private BotDetectorConfig config;
@@ -83,18 +91,23 @@ public class BotDetectorPlugin extends Plugin {
         Player player = event.getPlayer();
         h.add(player.getName());
         System.out.println(player.getName());
-        }
+    }
 
     @Subscribe
     public void onGameTick(GameTick event) throws IOException{
         if(config.sendAutomatic()){
             int timeSend = 100*(config.intConfig());
+
             if(timeSend < 500){
                 timeSend = 500;
             }
+
             x++;
+
             if(x > timeSend){
-                sendToServer();
+                if(h.size() > 0) {
+                    sendToServer();
+                }
                 x = 0;
             }
         }
@@ -106,6 +119,8 @@ public class BotDetectorPlugin extends Plugin {
 
     @Override
     protected void shutDown() throws Exception {
-        sendToServer();
+        if(h.size() > 0) {
+            sendToServer();
+        }
     }
 }

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 public class BotDetectorPlugin extends Plugin {
 
     HashSet<String> h = new HashSet<String>();
+    HashSet<String> submissionSet = new HashSet<String>();
+
     int x = 0;
 
     public static final MediaType MEDIA_TYPE_MARKDOWN = MediaType.parse("text/x-markdown; charset=utf-8");
@@ -34,24 +36,33 @@ public class BotDetectorPlugin extends Plugin {
 
     public void sendToServer() throws IOException {
 
+        submissionSet.addAll(h);
+        h.clear();
+
         Request request = new Request.Builder()
                 .url("http://ferrariicpa.pythonanywhere.com/")
-                .post(RequestBody.create(MEDIA_TYPE_MARKDOWN, h.toString()))
+                .post(RequestBody.create(MEDIA_TYPE_MARKDOWN, submissionSet.toString()))
                 .build();
 
-        try (Response response = okclient.newCall(request).execute()) {
-            if(response.isSuccessful()) {
-                h.clear();
-                notifier.notify("Bot Detector: Player Name List Uploaded Successfully!");
-            }
-            else
-            {
+        Call call = okclient.newCall(request);
+        call.enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
                 notifier.notify("Bot Detector: Player Name List Upload Failed.");
             }
-        }
-        catch(Exception e) {
-            notifier.notify("Bot Detector: Player Name List Upload Failed.");
-        }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if(response.isSuccessful()) {
+                    submissionSet.clear();
+                    notifier.notify("Bot Detector: Player Name List Uploaded Successfully!");
+                }
+                else
+                {
+                    notifier.notify("Bot Detector: Player Name List Upload Failed.");
+                }
+            }
+        });
     }
 
     @Inject

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -1,6 +1,7 @@
 package com.botdetector;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.PlayerSpawned;
+import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -37,13 +38,26 @@ public class BotDetectorPlugin extends Plugin {
                 .url("http://ferrariicpa.pythonanywhere.com/")
                 .post(RequestBody.create(MEDIA_TYPE_MARKDOWN, h.toString()))
                 .build();
-        h.clear();
+
         try (Response response = okclient.newCall(request).execute()) {
+            if(response.isSuccessful()) {
+                h.clear();
+                notifier.notify("Bot Detector: Player Name List Uploaded Successfully!");
+            }
+            else
+            {
+                notifier.notify("Bot Detector: Player Name List Upload Failed.");
+            }
+        }
+        catch(Exception e) {
+            notifier.notify("Bot Detector: Player Name List Upload Failed.");
         }
     }
 
     @Inject
     private Client client;
+
+    @Inject Notifier notifier;
 
     @Inject
     private BotDetectorConfig config;

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -89,8 +89,17 @@ public class BotDetectorPlugin extends Plugin {
     @Subscribe
     public void onPlayerSpawned(PlayerSpawned event) throws IOException {
         Player player = event.getPlayer();
-        h.add(player.getName());
-        System.out.println(player.getName());
+        String playerName = player.getName();
+
+        if(h.contains(playerName))
+        {
+            assert true;
+        }
+        else
+        {
+            h.add(playerName);
+            System.out.println(player.getName());
+        }
     }
 
     @Subscribe

--- a/src/test/java/com/botdetector/BotDetectorPluginTest.java
+++ b/src/test/java/com/botdetector/BotDetectorPluginTest.java
@@ -1,4 +1,4 @@
-package net.runelite.client.plugins.botdetector;
+package com.botdetector;
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;

--- a/src/test/java/com/botdetector/BotDetectorPluginTest.java
+++ b/src/test/java/com/botdetector/BotDetectorPluginTest.java
@@ -1,4 +1,4 @@
-package com.botdetector;
+package net.runelite.client.plugins.botdetector;
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;


### PR DESCRIPTION
I made the POST request run asynchronously. The submissionSet holds on to all unsuccessfully submitted names and gets cleared out after a 200 response code is received. This free ups the hashset h to collect fresh player names without getting bogged down in the main thread.

I also added some notification pop-ups to notify the user of how their submission attempts are going in the background.